### PR TITLE
Remove unnecessary permission on bootstrap policy

### DIFF
--- a/bootstrap/iam/policy.json
+++ b/bootstrap/iam/policy.json
@@ -22,7 +22,6 @@
         "s3:PutBucketTagging",
         "SNS:CreateTopic",
         "SNS:ListTopics",
-        "iam:PassRole",
         "events:PutRule",
         "events:PutTargets",
         "dynamodb:CreateTable",


### PR DESCRIPTION
This PR removes unncessary permission (`iam:PassRole`) from bootstrap policy.